### PR TITLE
fix(web): Admin-Seiten vor unberechtigtem Zugriff schützen + Login-Seite

### DIFF
--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+// app/admin/layout.tsx
+import RequireAdminAuth from "@/components/RequireAdminAuth";
+
+/**
+ * AdminLayout wraps all admin subpages with an authentication guard.
+ *
+ * Unauthenticated users are redirected to the home page.
+ * This prevents the Verwaltung / admin pages from being visible
+ * without a valid login.
+ */
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <RequireAdminAuth>{children}</RequireAdminAuth>;
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,112 @@
+// app/login/page.tsx
+"use client";
+
+import { Button, Input } from "@heroui/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+
+import AnimatedGradient from "@/components/animatedGradient";
+
+/**
+ * LoginFormContent contains the actual login form logic.
+ *
+ * It's extracted into a separate component so that `useSearchParams`
+ * can be wrapped in <Suspense>, which is required by Next.js App Router.
+ */
+function LoginFormContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirect") || "/admin/overview";
+
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!username.trim() || !password.trim()) {
+      setError("Bitte Benutzername und Passwort eingeben.");
+      return;
+    }
+
+    // Store credentials in sessionStorage (same format as the existing login modal)
+    const credentials = btoa(`${username}:${password}`);
+    sessionStorage.setItem("credentials", credentials);
+
+    // Navigate to the intended destination
+    router.push(redirectTo);
+  };
+
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="bg-white dark:bg-gray-800 shadow-xl rounded-2xl p-8 border border-gray-200 dark:border-gray-700">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 text-center">
+            Anmelden
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 text-center">
+            Bitte gib deine Zugangsdaten für die Verwaltung ein.
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              isRequired
+              label="Benutzername"
+              placeholder="Benutzername"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+
+            <Input
+              isRequired
+              label="Passwort"
+              placeholder="Passwort"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+
+            {error && (
+              <div
+                className="p-3 text-sm text-red-700 bg-red-100 rounded-lg dark:bg-red-900 dark:text-red-200"
+                role="alert"
+              >
+                {error}
+              </div>
+            )}
+
+            <Button
+              className="w-full"
+              color="primary"
+              size="lg"
+              type="submit"
+            >
+              Anmelden
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * LoginPage renders the administrative login page.
+ *
+ * Users are redirected here from admin pages when they are not
+ * authenticated. After successful login the credentials are stored
+ * in sessionStorage and the user is forwarded to the originally
+ * requested page (or /admin/overview by default).
+ */
+export default function LoginPage() {
+  return (
+    <div>
+      <AnimatedGradient />
+      <Suspense>
+        <LoginFormContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/components/RequireAdminAuth.tsx
+++ b/apps/web/components/RequireAdminAuth.tsx
@@ -1,0 +1,43 @@
+// components/RequireAdminAuth.tsx
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+/**
+ * RequireAdminAuth is a client-side authentication guard for admin pages.
+ *
+ * It checks `sessionStorage` for stored credentials on mount.
+ * If no credentials are found, the user is redirected to the login page
+ * (`/login?redirect=<original_path>`). After successful login the user
+ * is sent back to the originally requested page.
+ * While the check is in progress, nothing is rendered (avoids flash of content).
+ *
+ * @param children - The protected content to render when authenticated.
+ */
+export default function RequireAdminAuth({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const credentials = sessionStorage.getItem("credentials");
+    if (!credentials) {
+      const encodedRedirect = encodeURIComponent(pathname);
+      router.push(`/login?redirect=${encodedRedirect}`);
+    } else {
+      setIsAuthorized(true);
+    }
+  }, [router, pathname]);
+
+  // Show nothing until we know the auth state (avoids flash of protected content)
+  if (isAuthorized !== true) {
+    return null;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Problem
Die Verwaltungsseite unter `/admin/overview` war für jeden Benutzer aufrufbar, der die URL kennt – auch ohne vorherige Anmeldung.

## Lösung

### 1. Auth-Guard (`components/RequireAdminAuth.tsx`)
Prüft `sessionStorage` auf Credentials. Fehlen diese → Weiterleitung zu `/login?redirect=...`

### 2. Login-Seite (`app/login/page.tsx`)
Login-Formular mit HeroUI-Komponenten. Nach Login → zurück zur ursprünglichen Seite.

### 3. Admin-Layout (`app/admin/layout.tsx`)
Schützt alle Seiten unter `/admin/*` mit dem Auth-Guard.

## Änderungen
```
apps/web/app/admin/layout.tsx            |  17 +
apps/web/app/login/page.tsx              | 112 +++
apps/web/components/RequireAdminAuth.tsx |  43 ++
```
3 Dateien, 172 Zeilen neu.